### PR TITLE
feat: refresh hero design and theme tokens

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -13,6 +13,11 @@ html {
   scroll-behavior: smooth;
 }
 
+html, body {
+  overflow-y: auto;
+  overflow-x: clip;
+}
+
 body {
   margin: 0;
   padding: 0;
@@ -55,11 +60,9 @@ body {
 :root,
 :root.dark,
 .dark {
-  --bg:#0b1220; --ink:#E6EAF2; --muted:#A6B0BF; --line:#1A2233; --accent:#88A9FF;
+  --bg:#0C1420; --ink:#DCE6FF; --muted:#7E8AA6; --line:#1A2233; --accent:#9DB8FF;
   --card:#0F172A; --chip:#0E213B;
-  --three-base:#0f1627; --three-highlight:#1b2438; --three-fog:#0b1220;
-  /* Hero headline fill leans toward navy on dark */
-  --headline-fill: color-mix(in oklab, var(--accent) 52%, var(--bg));
+  --three-base:#0f1627; --three-highlight:#1b2438; --three-fog:#0C1420;
   --snow: #E6EEF6;
   /* IDE overlay tokens */
   --ide-bg: color-mix(in oklab, var(--ink) 8%, black);
@@ -74,8 +77,6 @@ body {
   --bg:#f7f9fc; --ink:#0f172a; --muted:#475569; --line:#e2e8f0; --accent:#3b82f6;
   --card:#ffffff; --chip:#eef2f7;
   --three-base:#f3f6fb; --three-highlight:#e6edf7; --three-fog:#eef2f7;
-  /* Hero headline fill is a tempered blue on light */
-  --headline-fill: color-mix(in oklab, var(--accent) 60%, white);
   --snow: #AABCD4;
   /* IDE overlay tokens */
   --ide-bg: color-mix(in oklab, var(--ink) 6%, white);
@@ -88,6 +89,15 @@ body {
 /* Hide system cursor when CustomCursor is mounted */
 .cursor-none, .cursor-none * {
   cursor: none !important;
+}
+
+/* Hide scrollbars but keep scroll functionality */
+.no-scrollbar {
+  -ms-overflow-style: none;
+  scrollbar-width: none;
+}
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
 }
 
 /* (tokens consolidated above) */
@@ -143,13 +153,17 @@ body {
 
 /* Custom Sharlee hero utilities */
 .text-glow {
-  text-shadow:
-    0 1px 8px color-mix(in oklab, var(--headline-fill) 42%, transparent),
-    0 0 30px color-mix(in oklab, var(--accent) 26%, transparent);
+  text-shadow: 0 0 24px rgba(157,184,255,.25);
 }
 
 .stroke-1 {
   -webkit-text-stroke: 1.5px currentColor;
   -webkit-text-fill-color: transparent; /* keep fill invisible */
   color: inherit; /* preserve currentColor for stroke */
+}
+
+a:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 0.125rem;
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -25,8 +25,8 @@ export default function RootLayout({
 }) {
   const SnowCursor = dynamic(() => import('@/components/cursor/SnowCursor'), { ssr: false })
   return (
-    <html lang="en" suppressHydrationWarning className={`${inter.variable} ${outfit.variable}`}>
-      <body className={`antialiased bg-[var(--bg)] text-[var(--ink)]`}>
+    <html lang="en" suppressHydrationWarning className={`${inter.variable} ${outfit.variable} no-scrollbar`}>
+      <body className={`antialiased bg-[var(--bg)] text-[var(--ink)] overflow-x-clip`}>
         <ThemeProvider>
           {/* Minimal header with theme toggle */}
           <div className="fixed top-4 right-4 z-[1000]">
@@ -34,6 +34,7 @@ export default function RootLayout({
           </div>
           <SnowCursor />
           {children}
+          <div className="grain-overlay" aria-hidden />
         </ThemeProvider>
       </body>
     </html>

--- a/components/HeroSharlee.tsx
+++ b/components/HeroSharlee.tsx
@@ -3,6 +3,7 @@
 import BlobField from './BlobField'
 import dynamic from 'next/dynamic'
 import Headline from './hero/Headline'
+import CTAGroup from './hero/CTAGroup'
 import { LazyMotion, domAnimation, m } from 'framer-motion'
 import { Suspense, useState } from 'react'
 import { useHeroReveal } from '@/lib/useHeroReveal'
@@ -25,7 +26,7 @@ export default function HeroSharlee() {
   const canAnimate = mounted && shouldAnimate
 
   return (
-    <section className="relative min-h-[92dvh] overflow-hidden bg-[var(--bg)] transition-colors">
+    <section className="relative min-h-[100svh] overflow-hidden bg-brand-bg">
       <BlobField key={canAnimate ? 'anim' : 'static'} animate={!!canAnimate} reduced={!!reduced} />
       <div
         className="pointer-events-none absolute inset-0 mix-blend-overlay opacity-[0.035]"
@@ -34,51 +35,17 @@ export default function HeroSharlee() {
       <LazyMotion features={domAnimation}>
         <m.div
           key={canAnimate ? 'anim' : 'static'}
-          className="relative z-10 mx-auto max-w-5xl px-6 pt-24 pb-28 md:pb-32 text-center"
+          className="relative z-10 mx-auto flex min-h-[100svh] max-w-5xl flex-col items-center justify-center gap-6 px-6 pb-36 md:pb-40 text-center"
           initial={canAnimate && reduced ? { opacity: 0 } : undefined}
           animate={canAnimate && reduced ? { opacity: 1 } : undefined}
           transition={canAnimate && reduced ? { duration: 0.17, ease: 'easeOut' } : undefined}
         >
           <Headline animate={!!canAnimate} reduced={!!reduced} onComplete={onHeadlineComplete} />
-
-          <div className="mt-10 flex items-center justify-center gap-4">
-            <m.a
-              href="#projects"
-              className="rounded-full px-6 py-3 bg-brand-primary text-slate-900 font-semibold shadow-sm transition hover:-translate-y-0.5 focus:outline-none focus:ring-2 focus:ring-brand-primary/60"
-              data-cursor-fill="var(--ink)"
-              initial={canAnimate && !reduced ? { opacity: 0, y: 10, boxShadow: '0 0 0 0 rgba(0,0,0,0)' } : undefined}
-              animate={
-                canAnimate && !reduced
-                  ? headlineDone
-                    ? { opacity: 1, y: 0, boxShadow: '0 8px 24px rgba(0,0,0,0.16)' }
-                    : undefined
-                  : undefined
-              }
-              transition={canAnimate && !reduced ? { delay: ctaDelay, duration: 0.28, ease: 'easeOut' } : undefined}
-            >
-              View Projects
-            </m.a>
-            <m.a
-              href="#contact"
-              className="rounded-full px-6 py-3 text-[var(--ink)] ring-1 ring-[var(--line)] bg-[var(--ide-bg)] transition hover:bg-[var(--ide-chrome)] focus:outline-none focus:ring-2 focus:ring-[var(--accent)]/50"
-              data-cursor-fill="var(--ink)"
-              initial={canAnimate && !reduced ? { opacity: 0, y: 10, boxShadow: '0 0 0 0 rgba(0,0,0,0)' } : undefined}
-              animate={
-                canAnimate && !reduced
-                  ? headlineDone
-                    ? { opacity: 1, y: 0, boxShadow: '0 8px 22px rgba(0,0,0,0.12)' }
-                    : undefined
-                  : undefined
-              }
-              transition={canAnimate && !reduced ? { delay: ctaDelay, duration: 0.32, ease: 'easeOut' } : undefined}
-            >
-              Get In Touch
-            </m.a>
-          </div>
+          <CTAGroup animate={canAnimate && !reduced} visible={headlineDone} delay={ctaDelay} />
         </m.div>
       </LazyMotion>
       {/* Mountain band pinned to bottom */}
-      <div className="mountain-band pointer-events-none absolute inset-x-0 bottom-0 z-0 h-[26vh] sm:h-[22vh] md:h-[28vh]">
+      <div className="mountain-band pointer-events-none absolute inset-x-0 bottom-0 z-0 h-[30vh] sm:h-[24vh] md:h-[34vh]">
         <Suspense
           fallback={<div className="w-full h-full" aria-hidden />}
         >

--- a/components/cursor/types.ts
+++ b/components/cursor/types.ts
@@ -38,11 +38,11 @@ export type CursorSettings = {
 }
 
 export const defaultSettings: CursorSettings = {
-  maxParticles: 150,
-  baseRate: 8, // particles/sec at idle
-  ratePerSpeed: 0.04, // per px/sec
-  clickBurstMin: 12,
-  clickBurstMax: 18,
+  maxParticles: 90,
+  baseRate: 5, // particles/sec at idle
+  ratePerSpeed: 0.025, // per px/sec
+  clickBurstMin: 8,
+  clickBurstMax: 12,
   dprMax: 1.75,
 }
 

--- a/components/hero/CTAGroup.tsx
+++ b/components/hero/CTAGroup.tsx
@@ -1,0 +1,37 @@
+"use client"
+
+import { LazyMotion, domAnimation, m } from 'framer-motion'
+
+interface Props {
+  animate: boolean
+  visible: boolean
+  delay?: number
+}
+
+export default function CTAGroup({ animate, visible, delay = 0 }: Props) {
+  return (
+    <LazyMotion features={domAnimation}>
+      <m.div
+        className="mt-10 flex items-center justify-center gap-8"
+        initial={animate ? { opacity: 0, y: 10 } : undefined}
+        animate={animate ? (visible ? { opacity: 1, y: 0 } : undefined) : undefined}
+        transition={animate ? { delay, duration: 0.28, ease: 'easeOut' } : undefined}
+      >
+        <a
+          href="/work"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-md px-3 py-2 text-[15px] font-medium text-brand-ink/85 transition-colors hover:text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        >
+          <span>see my projects</span>
+          <span className="transition-transform group-hover:translate-x-0.5">→</span>
+        </a>
+        <a
+          href="/about"
+          className="group inline-flex min-h-11 items-center gap-2 rounded-md px-3 py-2 text-[15px] font-medium text-brand-ink/85 transition-colors hover:text-brand-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-accent focus-visible:ring-offset-2 focus-visible:ring-offset-brand-bg"
+        >
+          <span>more about me</span>
+          <span className="transition-transform group-hover:translate-x-0.5">→</span>
+        </a>
+      </m.div>
+    </LazyMotion>
+  )
+}

--- a/components/hero/Headline.tsx
+++ b/components/hero/Headline.tsx
@@ -1,7 +1,6 @@
 "use client"
 
 import { LazyMotion, domAnimation, m } from 'framer-motion'
-import DesignStroke from './DesignStroke'
 import { useEffect, useState } from 'react'
 
 type Props = {
@@ -27,14 +26,14 @@ export default function Headline({ animate, reduced, onComplete }: Props) {
 
   return (
     <div className="text-center">
-      <p className="mb-6 text-xs uppercase tracking-[0.25em] text-[var(--muted)] font-body">
+      <p className="mb-6 text-xs uppercase tracking-[0.25em] text-brand-muted font-body">
         OWEN | DATA SCIENCE &times; SOFTWARE ENGINEER
       </p>
 
       <LazyMotion features={domAnimation}>
         <m.h1
           key={animate && !reduced ? 'reveal' : 'static'}
-          className="font-display font-extrabold leading-[0.9] tracking-wide uppercase text-6xl sm:text-7xl md:text-8xl"
+          className="font-display font-extrabold leading-[0.9] tracking-[0.1em] uppercase text-6xl sm:text-7xl md:text-8xl"
           initial={animate && !reduced ? 'hidden' : undefined}
           animate={animate && !reduced ? 'visible' : undefined}
           variants={
@@ -56,7 +55,7 @@ export default function Headline({ animate, reduced, onComplete }: Props) {
         >
           {/* ANALYZE */}
           <m.span
-            className="block text-[var(--headline-fill)] text-glow"
+            className="block text-brand-ink text-glow"
               variants={
                 animate && !reduced
                   ? {
@@ -71,17 +70,21 @@ export default function Headline({ animate, reduced, onComplete }: Props) {
 
           {/* DESIGN + BUILD row */}
           <m.span className="block">
-            {/* DESIGN (true stroke draw via SVG text dash) */}
-            <DesignStroke
-              text="Design"
-              animate={animate}
-              reduced={reduced}
-              duration={designDur}
-              className="inline-block text-brand-primary/90"
-            />
-            {/* BUILD */}
             <m.span
-              className="ml-3 inline-block text-[var(--headline-fill)] text-glow"
+              className="inline-block stroke-1 text-brand-accent"
+              variants={
+                animate && !reduced
+                  ? {
+                      hidden: { opacity: 0, y: 12 },
+                      visible: { opacity: 1, y: 0, transition: { duration: designDur, ease: 'easeOut' } },
+                    }
+                  : undefined
+              }
+            >
+              Design
+            </m.span>
+            <m.span
+              className="ml-3 inline-block text-brand-ink text-glow"
               variants={
                 animate && !reduced
                   ? {
@@ -107,7 +110,7 @@ export default function Headline({ animate, reduced, onComplete }: Props) {
       {/* Subline after headline completes */}
       <LazyMotion features={domAnimation}>
         <m.p
-          className="mt-6 text-[var(--muted)] max-w-2xl mx-auto font-body"
+          className="mt-6 text-brand-muted max-w-2xl mx-auto font-body"
           initial={animate && !reduced ? { opacity: 0, y: 8 } : undefined}
           animate={
             animate && !reduced

--- a/components/hero/MountainBand.tsx
+++ b/components/hero/MountainBand.tsx
@@ -96,12 +96,13 @@ export default function MountainBand({
         transition={{ duration: effectiveReduced ? 0.2 : 0.42, ease: 'easeOut' }}
         className="w-full h-full"
       >
-        <Canvas
-          className="w-full h-full"
-          dpr={[1, 1.75]}
-          gl={{ antialias: true, alpha: true }}
-          frameloop={warm ? 'always' : 'demand'}
-          camera={{ fov: 35, position: [0, 14, 42] }}
+          <Canvas
+            className="w-full h-full"
+            style={{ pointerEvents: 'none' }}
+            dpr={[1, 1.75]}
+            gl={{ antialias: true, alpha: true }}
+            frameloop={warm ? 'always' : 'demand'}
+            camera={{ fov: 35, position: [0, 14, 42] }}
           eventSource={typeof window !== 'undefined' ? (document as any) : undefined}
           onCreated={(state) => {
             state.gl.setClearColor(0x000000, 0)
@@ -218,28 +219,29 @@ function Scene({
 
   return (
     <>
-      <ambientLight intensity={0.48} />
-      <hemisphereLight args={[0x7aa2ff, 0x0b1220, 0.35]} />
-      <directionalLight position={[-26, 38, 24]} intensity={1.4} color={0xfff3e6} />
-      <directionalLight position={[30, 28, -10]} intensity={0.45} color={0x9bc3ff} />
+        <ambientLight intensity={0.48} />
+        <hemisphereLight args={[0x7aa2ff, 0x0b1220, 0.35]} />
+        <directionalLight position={[-26, 38, 24]} intensity={1.2} color={0xfff3e6} />
+        <directionalLight position={[30, 28, -10]} intensity={0.45} color={0x9bc3ff} />
+        <fog attach="fog" args={[baseTheme.fog, 40, 140]} />
 
       {/* Far layer */}
       <group position={[0, -5.6, -46]} scale={[1.30, 1, 1]}>
-        <mesh geometry={geoFar}>
-          <LowPolyMaterial roughness={0.82} metalness={0.0} />
-        </mesh>
+          <mesh geometry={geoFar}>
+            <LowPolyMaterial roughness={0.82} metalness={0.0} envMapIntensity={0.3} />
+          </mesh>
       </group>
       {/* Mid layer */}
       <group position={[0, -4.8, -32]} scale={[1.22, 1, 1]}>
-        <mesh geometry={geoMid}>
-          <LowPolyMaterial roughness={0.78} metalness={0.02} />
-        </mesh>
+          <mesh geometry={geoMid}>
+            <LowPolyMaterial roughness={0.78} metalness={0.02} envMapIntensity={0.3} />
+          </mesh>
       </group>
       {/* Near layer */}
       <group position={[0, -3.8, -20]} scale={[1.12, 1, 1]}>
-        <mesh geometry={geoNear}>
-          <LowPolyMaterial roughness={0.76} metalness={0.03} />
-        </mesh>
+          <mesh geometry={geoNear}>
+            <LowPolyMaterial roughness={0.76} metalness={0.03} envMapIntensity={0.3} />
+          </mesh>
       </group>
     </>
   )

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
+        "@typescript-eslint/eslint-plugin": "^8.43.0",
+        "@typescript-eslint/parser": "^8.43.0",
         "autoprefixer": "^10.0.1",
         "esbuild": "^0.21.5",
         "eslint": "^8",
@@ -1440,61 +1442,161 @@
       "integrity": "sha512-GPe4AsfOSpqWd3xA/0gwoKod13ChcfV67trvxaW2krUbgb9gxQjnCx8zGshzMl8LSHZlNH5gQ8LNScsDuc7nGQ==",
       "license": "MIT"
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
-      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+    "node_modules/@typescript-eslint/eslint-plugin": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.43.0.tgz",
+      "integrity": "sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==",
       "dev": true,
-      "license": "BSD-2-Clause",
+      "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "6.21.0",
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/typescript-estree": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4"
+        "@eslint-community/regexpp": "^4.10.0",
+        "@typescript-eslint/scope-manager": "8.43.0",
+        "@typescript-eslint/type-utils": "8.43.0",
+        "@typescript-eslint/utils": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0",
+        "graphemer": "^1.4.0",
+        "ignore": "^7.0.0",
+        "natural-compare": "^1.4.0",
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "eslint": "^7.0.0 || ^8.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
+        "@typescript-eslint/parser": "^8.43.0",
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
-      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+    "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+      "version": "7.0.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+      "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.43.0.tgz",
+      "integrity": "sha512-B7RIQiTsCBBmY+yW4+ILd6mF5h1FUwJsVvpqkrgpszYifetQ2Ke+Z4u6aZh0CblkUGIdR59iYVyXqqZGkZ3aBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0"
+        "@typescript-eslint/scope-manager": "8.43.0",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0",
+        "debug": "^4.3.4"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.43.0.tgz",
+      "integrity": "sha512-htB/+D/BIGoNTQYffZw4uM4NzzuolCoaA/BusuSIcC8YjmBYQioew5VUZAYdAETPjeed0hqCaW7EHg+Robq8uw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.43.0",
+        "@typescript-eslint/types": "^8.43.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.43.0.tgz",
+      "integrity": "sha512-daSWlQ87ZhsjrbMLvpuuMAt3y4ba57AuvadcR7f3nl8eS3BjRc8L9VLxFLk92RL5xdXOg6IQ+qKjjqNEimGuAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/@typescript-eslint/types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
-      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.43.0.tgz",
+      "integrity": "sha512-ALC2prjZcj2YqqL5X/bwWQmHA2em6/94GcbB/KKu5SX3EBDOsqztmmX1kMkvAJHzxk7TazKzJfFiEIagNV3qEA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.43.0.tgz",
+      "integrity": "sha512-qaH1uLBpBuBBuRf8c1mLJ6swOfzCXryhKND04Igr4pckzSEW9JX5Aw9AgW00kwfjWJF0kk0ps9ExKTfvXfw4Qg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0",
+        "@typescript-eslint/utils": "8.43.0",
+        "debug": "^4.3.4",
+        "ts-api-utils": "^2.1.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.43.0.tgz",
+      "integrity": "sha512-vQ2FZaxJpydjSZJKiSW/LJsabFFvV7KgLC5DiLhkBcykhQj8iK9BOaDmQt74nnKdLvceM5xmhaTF+pLekrxEkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
@@ -1502,66 +1604,87 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
-      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "@typescript-eslint/visitor-keys": "6.21.0",
-        "debug": "^4.3.4",
-        "globby": "^11.1.0",
-        "is-glob": "^4.0.3",
-        "minimatch": "9.0.3",
-        "semver": "^7.5.4",
-        "ts-api-utils": "^1.0.1"
-      },
-      "engines": {
-        "node": "^16.0.0 || >=18.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
-      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=16 || 14 >=14.17"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
-      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.43.0.tgz",
+      "integrity": "sha512-7Vv6zlAhPb+cvEpP06WXXy/ZByph9iL6BQRBDj4kmBsW98AqEeQHlj/13X+sZOrKSo9/rNKH4Ul4f6EICREFdw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "6.21.0",
-        "eslint-visitor-keys": "^3.4.1"
+        "@typescript-eslint/project-service": "8.43.0",
+        "@typescript-eslint/tsconfig-utils": "8.43.0",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/visitor-keys": "8.43.0",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.2",
+        "is-glob": "^4.0.3",
+        "minimatch": "^9.0.4",
+        "semver": "^7.6.0",
+        "ts-api-utils": "^2.1.0"
       },
       "engines": {
-        "node": "^16.0.0 || >=18.0.0"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.43.0.tgz",
+      "integrity": "sha512-S1/tEmkUeeswxd0GGcnwuVQPFWo8NzZTOMxCvw8BX7OMxnNae+i8Tm7REQen/SwUIPoPqfKn7EaZ+YLpiB3k9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@eslint-community/eslint-utils": "^4.7.0",
+        "@typescript-eslint/scope-manager": "8.43.0",
+        "@typescript-eslint/types": "8.43.0",
+        "@typescript-eslint/typescript-estree": "8.43.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0",
+        "typescript": ">=4.8.4 <6.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.43.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.43.0.tgz",
+      "integrity": "sha512-T+S1KqRD4sg/bHfLwrpF/K3gQLBM1n7Rp7OjjikjTEssI2YJzQpi5WXoynOaQ93ERIuq3O8RBTOUYDKszUCEHw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.43.0",
+        "eslint-visitor-keys": "^4.2.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@ungap/structured-clone": {
@@ -3181,6 +3304,143 @@
         "typescript": {
           "optional": true
         }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/parser": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.21.0.tgz",
+      "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "6.21.0",
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/typescript-estree": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/scope-manager": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.21.0.tgz",
+      "integrity": "sha512-OwLUIWZJry80O99zvqXVEioyniJMa+d2GrqpUTqi5/v5D5rOrppJVBPa0yKCblcigC0/aYAzxxqQ1B+DS2RYsg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.21.0.tgz",
+      "integrity": "sha512-1kFmZ1rOm5epu9NZEZm1kckCDGj5UJEf7P1kliH4LKu/RkwpsfqqGmY2OOcUs18lSlQBKLDYBOGxRVtrMN5lpg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/typescript-estree": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.21.0.tgz",
+      "integrity": "sha512-6npJTkZcO+y2/kr+z0hc4HwNfrrP4kNYh57ek7yCNlrBjWQ1Y0OS7jiZTkgumrvkX5HkEKXFZkkdFNkaW2wmUQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "@typescript-eslint/visitor-keys": "6.21.0",
+        "debug": "^4.3.4",
+        "globby": "^11.1.0",
+        "is-glob": "^4.0.3",
+        "minimatch": "9.0.3",
+        "semver": "^7.5.4",
+        "ts-api-utils": "^1.0.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/@typescript-eslint/visitor-keys": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.21.0.tgz",
+      "integrity": "sha512-JJtkDduxLi9bivAB+cYOVMtbkqdPOhZ+ZI5LC47MIRrDV4Yn2o+ZnW10Nkmr28xRpSpdJ6Sm42Hjf2+REYXm0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "6.21.0",
+        "eslint-visitor-keys": "^3.4.1"
+      },
+      "engines": {
+        "node": "^16.0.0 || >=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/eslint-config-next/node_modules/ts-api-utils": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.2.0"
       }
     },
     "node_modules/eslint-import-resolver-node": {
@@ -7037,16 +7297,16 @@
       "license": "MIT"
     },
     "node_modules/ts-api-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-      "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+      "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=16"
+        "node": ">=18.12"
       },
       "peerDependencies": {
-        "typescript": ">=4.2.0"
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-interface-checker": {

--- a/package.json
+++ b/package.json
@@ -28,15 +28,17 @@
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",
+    "@typescript-eslint/eslint-plugin": "^8.43.0",
+    "@typescript-eslint/parser": "^8.43.0",
     "autoprefixer": "^10.0.1",
+    "esbuild": "^0.21.5",
     "eslint": "^8",
     "eslint-config-next": "14.0.4",
+    "fast-glob": "^3.3.2",
+    "micromatch": "^4.0.5",
     "postcss": "^8",
     "prettier": "^3.1.0",
     "tailwindcss": "^3.3.0",
-    "typescript": "^5",
-    "esbuild": "^0.21.5",
-    "fast-glob": "^3.3.2",
-    "micromatch": "^4.0.5"
+    "typescript": "^5"
   }
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -13,9 +13,10 @@ const config: Config = {
     extend: {
       colors: {
         brand: {
-          bg: '#0c1420',
-          primary: '#9db8ff',
-          secondary: '#59e0ff',
+          bg: '#0C1420',
+          ink: '#DCE6FF',
+          accent: '#9DB8FF',
+          muted: '#7E8AA6',
         },
       },
       fontFamily: {


### PR DESCRIPTION
## Summary
- revamp hero with centered lock-up, new blob field, and text-link CTAs
- extend tailwind theme and global styles for brand tokens, focus rings, and scrollbar hiding
- tweak mountain band lighting and cursor density for a cleaner background

## Testing
- `npm run lint` *(fails: React hook dependencies, unexpected any, and other lint errors)*
- `npm run build` *(fails: same lint errors halt build)*

------
https://chatgpt.com/codex/tasks/task_e_68c6ff3d69e08331b1b0b8cfdf497d37